### PR TITLE
Ignore and Pardon now use the general channel from config if possible

### DIFF
--- a/bots/core.py
+++ b/bots/core.py
@@ -562,6 +562,13 @@ def EnableUtils(bot): #prolly move to it's own bot
                 )
                 for server in self.servers:
                     user = server.get_member(uid)
+                    general = self.fetch_channel('general')
+                    if general.server != server:
+                        general = discord.utils.get(
+                            server.channels,
+                            name='general',
+                            type=discord.ChannelType.text
+                        )
                     if self.config_get('ignore_role') != None:
                         blacklist_role = self.config_get('ignore_role')
                         for role in server.roles:
@@ -572,11 +579,7 @@ def EnableUtils(bot): #prolly move to it's own bot
                                 )
                     try:
                         await self.send_message(
-                            discord.utils.get(
-                                server.channels,
-                                name='general',
-                                type=discord.ChannelType.text
-                            ),
+                            general,
                             "%s has asked me to ignore %s. %s can no longer issue any commands"
                             " until they have been `!pardon`-ed" % (
                                 str(message.author),
@@ -625,6 +628,13 @@ def EnableUtils(bot): #prolly move to it's own bot
                 )
                 for server in self.servers:
                     user = server.get_member(uid)
+                    general = self.fetch_channel('general')
+                    if general.server != server:
+                        general = discord.utils.get(
+                            server.channels,
+                            name='general',
+                            type=discord.ChannelType.text
+                        )
                     if self.config_get('ignore_role') != None:
                         blacklist_role = self.config_get('ignore_role')
                         for role in server.roles:
@@ -635,11 +645,7 @@ def EnableUtils(bot): #prolly move to it's own bot
                                 )
                     try:
                         await self.send_message(
-                            discord.utils.get(
-                                server.channels,
-                                name='general',
-                                type=discord.ChannelType.text
-                            ),
+                            general,
                             "%s has pardoned %s" % (
                                 str(message.author),
                                 str(user)


### PR DESCRIPTION
However, it will just use a server's actual general if the server isn't the one that config.general is bound to